### PR TITLE
7: Trim Whitespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezweave/what-name-branch",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Branch naming can be hard.",
   "main": "dist/index.js",
   "repository": "git@github.com:ezweave/what-name-branch.git",

--- a/src/__fixtures__/StoryIssueFixtureWithSpaces.ts
+++ b/src/__fixtures__/StoryIssueFixtureWithSpaces.ts
@@ -1,0 +1,7 @@
+import { Issue, IssueType } from '../types';
+
+export const StoryIssueFixtureWithSpaces: Issue = {
+  description: '               you both present sick arguments                 ',
+  name: '            FOO-420              ',
+  type: IssueType.STORY,
+};

--- a/src/__fixtures__/index.ts
+++ b/src/__fixtures__/index.ts
@@ -1,1 +1,2 @@
 export * from './StoryIssueFixture';
+export * from './StoryIssueFixtureWithSpaces';

--- a/src/util/__snapshots__/convertDescription.test.ts.snap
+++ b/src/util/__snapshots__/convertDescription.test.ts.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[` converts any description to a git/file safe name 1`] = `"the-s3-notifications-are-too-notify-how-fix-"`;
+
+exports[` trims all tralining and leading whitespace 1`] = `"the-s3-notifications-are-too-notify-how-fix-"`;

--- a/src/util/buildResponse.ts
+++ b/src/util/buildResponse.ts
@@ -5,6 +5,7 @@ import { getRandomElementFromArray } from './getRandomElementFromArray';
 
 export const buildResponse = (
   branchName: string,
-): string => `${chalk.green(getRandomElementFromArray(Presponses))}
- ${chalk.bgWhite.blue('Your branch name is:')} ${branchName}
- ${getRandomElementFromArray(Responses)}${getRandomElementFromArray(Emojis)}`;
+): string => `
+${chalk.green(getRandomElementFromArray(Presponses))}
+${chalk.bgWhite.blue('Your branch name is:')} ${branchName}
+${getRandomElementFromArray(Responses)}${getRandomElementFromArray(Emojis)}`;

--- a/src/util/convertDescription.test.ts
+++ b/src/util/convertDescription.test.ts
@@ -6,6 +6,11 @@ describe(convertDescription, () => {
       convertDescription('the S3 notifications are too notify!  how fix? #!@##$'),
     ).toMatchSnapshot();
   });
+  it('trims all tralining and leading whitespace', () => {
+    expect(
+      convertDescription('             the S3 notifications are too notify!  how fix? #!@##$      '),
+    ).toMatchSnapshot();
+  });
   it('removes unsafe characters', () => {
     expect(
       convertDescription('issue-name$#!@%$*&))"\''),

--- a/src/util/convertDescription.ts
+++ b/src/util/convertDescription.ts
@@ -1,11 +1,13 @@
 import { flow, toLower } from 'lodash';
 import { replace as replaceFP } from 'lodash/fp';
+import { trim } from './trim';
 
 interface ConvertDescription {
   (description: string): string,
 }
 
 export const convertDescription: ConvertDescription = flow(
+  trim,
   toLower,
   replaceFP(/\s+/g, '-'),
   replaceFP(/[^\w-_]+/g, ''),

--- a/src/util/generateBranchName.test.ts
+++ b/src/util/generateBranchName.test.ts
@@ -1,4 +1,4 @@
-import { StoryIssueFixture } from '../__fixtures__';
+import { StoryIssueFixture, StoryIssueFixtureWithSpaces } from '../__fixtures__';
 import { generateBranchName } from './generateBranchName';
 
 describe(generateBranchName, () => {
@@ -6,5 +6,10 @@ describe(generateBranchName, () => {
     expect(
       generateBranchName(StoryIssueFixture),
     ).toMatchSnapshot();
+  });
+  it('generates a branch name, trimming spaces', () => {
+    expect(
+      generateBranchName(StoryIssueFixtureWithSpaces),
+    ).toEqual(generateBranchName(StoryIssueFixture));
   });
 });

--- a/src/util/generateBranchName.ts
+++ b/src/util/generateBranchName.ts
@@ -1,13 +1,19 @@
-import { toUpper } from 'lodash';
+import { flow, toUpper } from 'lodash';
 import { Issue } from '../types';
 import { convertDescription } from './convertDescription';
+import { trim } from './trim';
 
 interface GenerateBranchName {
   (issue: Issue): string,
 }
+
+const convertName = flow(
+  trim,
+  toUpper,
+);
  
 export const generateBranchName: GenerateBranchName = ({
   description,
   name,
   type,
-}) => `${type}/${toUpper(name)}/${convertDescription(description)}`;
+}) => `${type}/${convertName(name)}/${convertDescription(description)}`;

--- a/src/util/trim.test.ts
+++ b/src/util/trim.test.ts
@@ -1,0 +1,9 @@
+import { trim } from "./trim";
+
+describe(trim, () => {
+  it('trims a string', () => {
+    expect(
+      trim(' foo      ')
+    ).toEqual('foo');
+  })
+})

--- a/src/util/trim.test.ts
+++ b/src/util/trim.test.ts
@@ -1,9 +1,9 @@
-import { trim } from "./trim";
+import { trim } from './trim';
 
 describe(trim, () => {
   it('trims a string', () => {
     expect(
-      trim(' foo      ')
+      trim(' foo      '),
     ).toEqual('foo');
-  })
-})
+  });
+});

--- a/src/util/trim.ts
+++ b/src/util/trim.ts
@@ -1,4 +1,4 @@
-import { trim as trimLodash } from "lodash";
+import { trim as trimLodash } from 'lodash';
 
 /** 
  * TS has issues with the types for lodash' trim, so we wrap it. 

--- a/src/util/trim.ts
+++ b/src/util/trim.ts
@@ -1,0 +1,6 @@
+import { trim as trimLodash } from "lodash";
+
+/** 
+ * TS has issues with the types for lodash' trim, so we wrap it. 
+ */
+export const trim = (str: string) => trimLodash(str);


### PR DESCRIPTION
## Overview

Trims whitespace on user input (description and name).  Cleans up formatting a little on output.

## GitHub Issue addressed by this PR

- [7](https://github.com/ezweave/what-name-branch/issues/7): Trim Whitespace
